### PR TITLE
Feature/4 0.12 upgrade

### DIFF
--- a/examples/gce-acme/README.md
+++ b/examples/gce-acme/README.md
@@ -13,6 +13,10 @@ This example shows how to create an ACME generated SSL certificate for a GCE ins
 [[ `basename $PWD` != gce-acme ]] && cd gce-acme
 ```
 
+## Compatibility
+
+This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html) and need a Terraform 0.11.x-compatible version of this module, the last released version intended for Terraform 0.11.x is [1.1.0](https://registry.terraform.io/modules/terraform-google-modules/endpoints-dns/google/1.1.0).
+
 ## Install Terraform
 
 1. Install Terraform if it is not already installed (visit [terraform.io](https://terraform.io) for other distributions):
@@ -42,7 +46,7 @@ export GOOGLE_PROJECT=$(gcloud config get-value project)
 
 ## Create terraform.tfvars file
 
-1. Add your ACME notification email to the `terraform.tfvars` file: 
+1. Add your ACME notification email to the `terraform.tfvars` file:
 
 ```
 ACME_EMAIL=$(gcloud config get-value account)

--- a/examples/gce-acme/main.tf
+++ b/examples/gce-acme/main.tf
@@ -15,7 +15,6 @@
  */
 
 provider "google" {
-  region = var.region
 }
 
 data "google_client_config" "current" {
@@ -23,7 +22,7 @@ data "google_client_config" "current" {
 
 resource "google_compute_network" "default" {
   name                    = var.name
-  auto_create_subnetworks = "false"
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {

--- a/examples/gce-acme/main.tf
+++ b/examples/gce-acme/main.tf
@@ -15,94 +15,96 @@
  */
 
 provider "google" {
-  region = "${var.region}"
+  region = var.region
 }
 
-data "google_client_config" "current" {}
+data "google_client_config" "current" {
+}
 
 resource "google_compute_network" "default" {
-  name                    = "${var.name}"
+  name                    = var.name
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "default" {
-  name                     = "${var.name}"
+  name                     = var.name
   ip_cidr_range            = "10.127.0.0/20"
-  network                  = "${google_compute_network.default.self_link}"
-  region                   = "${var.region}"
+  network                  = google_compute_network.default.self_link
+  region                   = var.region
   private_ip_google_access = true
 }
 
 // Cloud Endpoint DNS record created with the IP of the instance.
 module "cloud-ep-dns" {
   source      = "../../"
-  project     = "${data.google_client_config.current.project}"
-  name        = "${var.name}"
-  external_ip = "${google_compute_instance.default.network_interface.0.access_config.0.assigned_nat_ip}"
+  project     = data.google_client_config.current.project
+  name        = var.name
+  external_ip = google_compute_instance.default.network_interface[0].access_config[0].assigned_nat_ip
 }
 
-data "google_compute_default_service_account" "default" { }
+data "google_compute_default_service_account" "default" {
+}
 
 resource "google_compute_instance" "default" {
-  name         = "${var.name}"
+  name         = var.name
   machine_type = "g1-small"
-  zone         = "${var.zone}"
+  zone         = var.zone
 
-  boot_disk = {
-    initialize_params = {
+  boot_disk {
+    initialize_params {
       image = "debian-cloud/debian-9"
       size  = "10"
     }
   }
 
-  network_interface = {
-    access_config = {}
-    subnetwork    = "${google_compute_subnetwork.default.name}"
+  network_interface {
+    access_config {
+    }
+    subnetwork = google_compute_subnetwork.default.name
   }
 
   metadata = {
-    ACME_EMAIL  = "${var.acme_email}"
-    ACME_SERVER = "${var.acme_server}"
-
+    ACME_EMAIL  = var.acme_email
+    ACME_SERVER = var.acme_server
     // note that the output variable referenced here is not dependent on the endpoint creation.
     // This is done so that we can use the ephemeral nat_ip of the instance in the cloud endpoint without creating a dependency cycle.
     // The instance startup script has a step to wait for the DNS to propagate before attempting the acme challenge.
-    ENDPOINT = "${module.cloud-ep-dns.endpoint}"
+    ENDPOINT = module.cloud-ep-dns.endpoint
   }
 
-  metadata_startup_script = "${file("${path.module}/startup.sh")}"
+  metadata_startup_script = file("${path.module}/startup.sh")
 
-  tags = ["${var.name}"]
+  tags = [var.name]
 
-  service_account = {
-    email = "${data.google_compute_default_service_account.default.email}"
+  service_account {
+    email  = data.google_compute_default_service_account.default.email
     scopes = ["userinfo-email", "compute-ro"]
   }
 }
 
 resource "google_compute_firewall" "ssh" {
   name    = "${var.name}-ssh"
-  network = "${google_compute_network.default.name}"
+  network = google_compute_network.default.name
 
-  allow = {
+  allow {
     protocol = "tcp"
     ports    = ["22"]
   }
 
-  target_service_accounts = ["${data.google_compute_default_service_account.default.email}"]
-  source_ranges = ["0.0.0.0/0"]
+  target_service_accounts = [data.google_compute_default_service_account.default.email]
+  source_ranges           = ["0.0.0.0/0"]
 }
 
 resource "google_compute_firewall" "default" {
   name    = "${var.name}-web"
-  network = "${google_compute_network.default.name}"
+  network = google_compute_network.default.name
 
-  allow = {
+  allow {
     protocol = "tcp"
     ports    = ["80", "443"]
   }
 
-  target_service_accounts = ["${data.google_compute_default_service_account.default.email}"]
+  target_service_accounts = [data.google_compute_default_service_account.default.email]
 }
 
 output "ssh" {
@@ -110,9 +112,9 @@ output "ssh" {
 }
 
 output "external_ip" {
-  value = "${module.cloud-ep-dns.external_ip}"
+  value = module.cloud-ep-dns.external_ip
 }
 
 output "endpoint" {
-  value = "${module.cloud-ep-dns.endpoint}"
+  value = module.cloud-ep-dns.endpoint
 }

--- a/examples/gce-acme/variables.tf
+++ b/examples/gce-acme/variables.tf
@@ -15,7 +15,7 @@
  */
 
 variable "acme_email" {
-    description = "Email to send ACME renewal notifications to."
+  description = "Email to send ACME renewal notifications to."
 }
 
 variable "acme_server" {
@@ -25,15 +25,15 @@ variable "acme_server" {
 
 variable "region" {
   description = "Region to configure the provider and create resources in."
-  default = "us-central1"
+  default     = "us-central1"
 }
 
 variable "zone" {
   description = "Zone to create resources like the subnetwork and compute_instance."
-  default = "us-central1-c"
+  default     = "us-central1-c"
 }
 
 variable "name" {
   description = "Name used for the endpoint and when creating resources like the network and compute_instance."
-  default = "tf-ep-dns"
+  default     = "tf-ep-dns"
 }

--- a/examples/gce-acme/versions.tf
+++ b/examples/gce-acme/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,7 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    google = "~> 2.19.0"
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 2.19.0"
+    google = "~> 2.19"
   }
 }


### PR DESCRIPTION
Fixes #4 

Root module was already upgraded but example was missing. 

Added `Compatibility` to readme

Added the `required_providers` for `google` to `2.0` version as I noticed some errors during a plan when it defaulted to 3.0 for the example.  