### PR TITLE
Loosen google provider contraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 2.19"
+    google = ">= 2.19, <4.0.0"
   }
 }


### PR DESCRIPTION
This updates the google provider constraint to match the method being used in https://github.com/terraform-google-modules/terraform-google-kubernetes-engine 

This will fix https://github.com/terraform-google-modules/terraform-google-endpoints-dns/issues/6