### PR TITLE
Fix: Remove upper bound on Google provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.53"
+      version = ">= 3.53"
     }
   }
 


### PR DESCRIPTION
Fixes #14 and aligns with guidance in the [Terraform docs](https://www.terraform.io/language/providers/requirements) to not use `~>` or other maximum-version constraints for providers in reusable modules.